### PR TITLE
fix docs for google_bigquery_default_service_account

### DIFF
--- a/third_party/terraform/website/docs/d/google_bigquery_default_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_bigquery_default_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "BigQuery"
 layout: "google"
 page_title: "Google: google_bigquery_default_service_account"
 sidebar_current: "docs-google-datasource-bigquery-default-service-account"


### PR DESCRIPTION
- fixup of #2784
- data source needed to get (or trigger creation) of BigQuery service account used for en-/decryption

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
